### PR TITLE
Add functionality for secrets.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ build
 # misc
 .DS_Store
 npm-debug.log
+
+#secrets
+secrets.js

--- a/secrets_template.js
+++ b/secrets_template.js
@@ -1,0 +1,9 @@
+const secrets = {
+  'db_uri': '<DATABASE_URI>',
+};
+
+module.exports = {
+  requestSecret: function(s) {
+    return secrets[s];
+  },
+};

--- a/server.js
+++ b/server.js
@@ -6,6 +6,7 @@ var express = require('express');
 var mongoose = require('mongoose');
 var bodyParser = require('body-parser');
 var Comment = require('./model/comments');
+var secrets = require('./secrets');
 
 //and create our instances
 var app = express();
@@ -14,8 +15,8 @@ var router = express.Router();
 //set our port to either a predetermined port number if you have set it up, or 3001
 var port = process.env.API_PORT || 3001;
 
-//db config -- REPLACE USERNAME/PASSWORD/DATABASE WITH YOUR OWN FROM MLAB!
-var mongoDB = 'mongodb://<DBUSERNAME>:<DBPASSWORD>@ds019836.mlab.com:19836/bryandb';
+//db config -- set your URI from mLab in secrets.js
+var mongoDB = secrets.requestSecret('db_uri');
 mongoose.connect(mongoDB, { useMongoClient: true })
 var db = mongoose.connection;
 db.on('error', console.error.bind(console, 'MongoDB connection error:'));


### PR DESCRIPTION
For developers who clone this project and want to make their own code public, it's a hassle to change sensitive information to <sensitive_information> (e.g. jsmith => <database_user>) whenever they commit a file containing the issue.
The solution is to add a secrets.js script ignored by git to export the information to relevant files. A public secrets_template.js exists to outline the behavior of the local secrets.js.